### PR TITLE
last changes

### DIFF
--- a/R/add1.R
+++ b/R/add1.R
@@ -85,7 +85,7 @@ drop1.logistf<-function(object, scope, test="PLR", ...){
     full.penalty.vec <- extras$full.penalty.vec
   }
   else full.penalty.vec <- NULL
-  variables<-attr(terms(object$formula),"term.labels")
+  variables<-object$terms[-1]#attr(terms(object$formula),"term.labels")
   nvar<-length(variables)
   if(!is.null(full.penalty.vec) && nvar!=length(full.penalty.vec)){ #exclude already removed variables - see backward
     matched <- match(full.penalty.vec, variables)+1 #+1: to include intercept

--- a/R/backward.r
+++ b/R/backward.r
@@ -48,6 +48,9 @@ backward.logistf <- function(object, scope, steps=1000, slstay=0.05, trace=TRUE,
   mf <- mf[c(1, m)]
   object <- eval(mf$object, parent.frame())
   variables <- object$terms[-1]
+  
+  terms.fit <- object$call$terms.fit
+  if(!is.null(terms.fit)) stop("Please call backward on a logistf-object with all terms fitted.")
 
   working<-object
   if(trace){
@@ -137,6 +140,9 @@ forward<-function(object, scope, steps=1000, slentry=0.05, trace=TRUE, printwork
   object <- eval(mf$object, parent.frame())
   variables <- object$terms[-1]
   
+  terms.fit <- object$call$terms.fit
+  if(!is.null(terms.fit)) stop("Please call forward on a logistf-object with all terms fitted.")
+  
   working<-object
   if(missing(scope)) {
     stop("Please provide scope (vector of variable names).\n")
@@ -194,6 +200,9 @@ backward.flac<-function(object, steps=1000, slstay=0.05, trace=TRUE, printwork=F
   mf <- mf[c(1, m)]
   object <- eval(mf$object, parent.frame())
   variables <- object$terms[-1]
+  
+  terms.fit <- object$call$terms.fit
+  if(!is.null(terms.fit)) stop("Please call backward on a logistf-object with all terms fitted.")
   
   working<-object
   if(trace){

--- a/R/flic.R
+++ b/R/flic.R
@@ -23,6 +23,7 @@
 #' \code{TRUE} for the outcome, where the higher value (1 or \code{TRUE}) is modeled.
 #' @param data If using with formula, a data frame containing the variables in the model. 
 #' @param lfobject A fitted \code{\link{logistf}} object
+#' @param model If TRUE the corresponding components of the fit are returned.
 #' @param ... Further arguments passed to the method or \code{\link{logistf}}-call.
 #'
 #' @return A \code{flic} object with components:
@@ -43,6 +44,7 @@
 #'   \item{formula}{The formula object.}
 #'   \item{control}{a copy of the control parameters.}  
 #'   \item{terms}{the model terms (column names of design matrix).}
+#'   \item{model}{if requested (the default), the model frame used.}
 #'   
 #' 
 #' @export
@@ -72,7 +74,7 @@ flic <- function(...){
 #' @exportS3Method flic formula
 #' @describeIn flic With formula and data
 #' @export flic.formula
-flic.formula <- function(formula,data,...){
+flic.formula <- function(formula,data,model = TRUE,...){
   extras <- list(...)
   call_out <- match.call()
   
@@ -136,8 +138,11 @@ flic.formula <- function(formula,data,...){
               method.ci=c("Wald", FL$method.ci[-1]), 
               ci.lower=c(ic-beta0.se*1.96, FL$ci.lower[-1]),
               ci.upper=c(ic+beta0.se*1.96, FL$ci.upper[-1]),
-              control = FL$control, 
+              control = FL$control 
               )
+  if(model) {
+    res$model <- mf
+  }
   attr(res, "class") <- c("flic")
   res
 }
@@ -147,7 +152,7 @@ flic.formula <- function(formula,data,...){
 #' @describeIn flic With logistf object
 #' @method flic logistf
 #' @exportS3Method flic logistf
-flic.logistf <- function(lfobject,...){
+flic.logistf <- function(lfobject,model=TRUE,...){
   extras <- list(...)
   call_out <- match.call()
 
@@ -155,6 +160,8 @@ flic.logistf <- function(lfobject,...){
   m <- match("lfobject", names(mf), 0L)
   mf <- mf[c(1, m)]
   lfobject <- eval(mf$lfobject, parent.frame())
+  if(!is.null(extras$formula)) lfobject <- update(lfobject, formula. = extras$formula) #to update flac.logistf objects at least with formula
+  
   variables <- lfobject$terms[-1]
   data <- model.frame(lfobject)
   
@@ -206,8 +213,11 @@ flic.logistf <- function(lfobject,...){
               method.ci=c("Wald", lfobject$method.ci[-1]), 
               ci.lower=c(ic-beta0.se*1.96, lfobject$ci.lower[-1]),
               ci.upper=c(ic+beta0.se*1.96, lfobject$ci.upper[-1]),
-              control = lfobject$control,
+              control = lfobject$control
               )
+  if(model) {
+    res$model <- lfobject$model
+  }
   attr(res, "class") <- c("flic")
   res
 }

--- a/man/flac.Rd
+++ b/man/flac.Rd
@@ -9,9 +9,9 @@
 \usage{
 flac(...)
 
-\method{flac}{formula}(formula, data, ...)
+\method{flac}{formula}(formula, data, model = TRUE, ...)
 
-\method{flac}{logistf}(lfobject, ...)
+\method{flac}{logistf}(lfobject, model = TRUE, ...)
 }
 \arguments{
 \item{...}{Further arguments passed to the method or \code{\link{logistf}}-call.}
@@ -21,6 +21,8 @@ and the model terms on the right. The response must be a vector with 0 and 1 or 
 \code{TRUE} for the outcome, where the higher value (1 or \code{TRUE}) is modeled.}
 
 \item{data}{If using with formula, a data frame containing the variables in the model.}
+
+\item{model}{If TRUE the corresponding components of the fit are returned.}
 
 \item{lfobject}{A fitted \code{\link{logistf}} object}
 }
@@ -44,6 +46,7 @@ A \code{flac} object with components:
   \item{method.ci}{the method in calculating the confidence intervals, i.e. `profile likelihood' or `Wald', depending on the argument pl and plconf.}
   \item{control}{a copy of the control parameters.}  
   \item{terms}{the model terms (column names of design matrix).}
+  \item{model}{if requested (the default), the model frame used.}
 }
 \description{
 \code{flac} implements Firth's bias-reduced penalized-likelihood logistic regression with added covariate.

--- a/man/flic.Rd
+++ b/man/flic.Rd
@@ -9,9 +9,9 @@
 \usage{
 flic(...)
 
-\method{flic}{formula}(formula, data, ...)
+\method{flic}{formula}(formula, data, model = TRUE, ...)
 
-\method{flic}{logistf}(lfobject, ...)
+\method{flic}{logistf}(lfobject, model = TRUE, ...)
 }
 \arguments{
 \item{...}{Further arguments passed to the method or \code{\link{logistf}}-call.}
@@ -21,6 +21,8 @@ and the model terms on the right. The response must be a vector with 0 and 1 or 
 \code{TRUE} for the outcome, where the higher value (1 or \code{TRUE}) is modeled.}
 
 \item{data}{If using with formula, a data frame containing the variables in the model.}
+
+\item{model}{If TRUE the corresponding components of the fit are returned.}
 
 \item{lfobject}{A fitted \code{\link{logistf}} object}
 }
@@ -43,6 +45,7 @@ A \code{flic} object with components:
   \item{formula}{The formula object.}
   \item{control}{a copy of the control parameters.}  
   \item{terms}{the model terms (column names of design matrix).}
+  \item{model}{if requested (the default), the model frame used.}
 }
 \description{
 \code{flic} implements Firth's bias-Reduced penalized-likelihood logistic regression with intercept correction.

--- a/man/logistf.Rd
+++ b/man/logistf.Rd
@@ -17,6 +17,7 @@ logistf(
   weights,
   plconf = NULL,
   flic = FALSE,
+  model = TRUE,
   ...
 )
 }
@@ -59,6 +60,8 @@ confidence intervals should be computed. Default is to compute for all variables
 \item{flic}{If \code{TRUE}, intercept is altered such that the predicted probabilities become unbiased while 
 keeping all other coefficients constant}
 
+\item{model}{If TRUE the corresponding components of the fit are returned.}
+
 \item{...}{Further arguments to be passed to \code{logistf}}
 }
 \value{
@@ -89,7 +92,8 @@ The object returned is of the class \code{logistf} and has the following attribu
    \item{pl.conv}{only if pl==TRUE: the convergence status (deviation of log likelihood from target value, last maximum change in beta) for each confidence limit.}
    \item{control}{a copy of the control parameters.}
    \item{flic}{logical, is TRUE  if intercept was altered such that the predicted probabilities become unbiased while 
-keeping all other coefficients constant. According to input of logistf.}
+keeping all other coefficients constant. According to input of logistf.}  
+   \item{model}{if requested (the default), the model frame used.}
 }
 \description{
 Implements Firth's bias-Reduced penalized-likelihood logistic regression.


### PR DESCRIPTION
vcov output of logistf(,flic=T) corrected; added error when applying BE/FW to logistf(,terms.fit=...); added error when terms in logistf(,terms.fit=...) cannot be found in formula; added model frame as output(apply BE to flac.logistf)

Backward should work now with flac.logistf objects.

Fixes #24, Fixes #25, Fixes #26,Fixes #27,Fixes #28.