### PR TITLE
Fixed a bug in the stepwise selection functions

### DIFF
--- a/R/backward.r
+++ b/R/backward.r
@@ -43,11 +43,6 @@ backward <- function(object,...){
 backward.logistf <- function(object, scope, steps=1000, slstay=0.05, trace=TRUE, printwork=FALSE,full.penalty=FALSE, ...){
   istep<-0 #index of steps
   
-  mf <- match.call(expand.dots =FALSE)
-  m <- match("object", names(mf), 0L)
-  mf <- mf[c(1, m)]
-  object <- eval(mf$object, parent.frame())
-  object <- update(object, formula=object$formula)
   variables <- attr(terms(object),"term.labels")
   form <- formula(terms(object)) #to take care of dot shortcut
   Terms <- terms(object)
@@ -163,10 +158,6 @@ forward <- function(object,...){
 forward.logistf<-function(object, scope, steps=1000, slentry=0.05, trace=TRUE, printwork=FALSE, pl=TRUE, ...){
   istep<-0
   
-  mf <- match.call(expand.dots =FALSE)
-  m <- match("object", names(mf), 0L)
-  mf <- mf[c(1, m)]
-  object <- eval(mf$object, parent.frame())
   variables <- object$terms[-1]
   
   terms.fit <- object$modcontrol$terms.fit


### PR DESCRIPTION
Theresa made me aware of a bug in `backward()`, see e.g. the following code:
```
data(sex2)

data_curr = sex2
FU_fit = logistf(formula = as.formula("case ~ age+oc+vic+vicl+vis+dia"), data = data_curr, flic = TRUE, model = TRUE)
backward(FU_fit)
rm(data_curr)

data_curr = data.frame()

f1 = function() {
  data_curr = sex2
  FU_fit = logistf(formula = as.formula("case ~ age+oc+vic+vicl+vis+dia"), data = data_curr, flic = TRUE, model = TRUE)
  backward(FU_fit)
}

f1()
```
This causes an error in the eval step because the dataset is not found in the parent environment (if it is also in the global environment, there is no problem). However, I think the eval step is not necessary, so in `backward()` and `forward()`, I removed the `model.frame()` and `eval()` step. This seems to solve the issue, but might have some unintended consequences elsewhere. So, I will do some more testing before merging this.
