### PR TITLE
Fixed bug in backward() and forward()

### DIFF
--- a/R/add1.R
+++ b/R/add1.R
@@ -33,13 +33,13 @@
 #' @rdname add1
 #' @method add1 logistf
 #' @exportS3Method add1 logistf
-add1.logistf<-function(object, scope, test="PLR", ...){
+add1.logistf<-function(object, scope, data, test="PLR", ...){
   if(missing(scope)) stop("please provide scope: no terms in scope for adding to object")
   else if(is.numeric(scope)) scope<-attr(terms(object),"term.labels")[scope]
   else if(!is.character(scope)) scope <- add.scope(object, update.formula(object, scope))
 
   mf <- match.call(expand.dots =FALSE)
-  m <- match(c("object", "scope", "test"), names(mf), 0L)
+  m <- match(c("object", "scope", "test", "data"), names(mf), 0L)
   mf <- mf[c(1, m)]
   object <- eval(mf$object, parent.frame())
   
@@ -52,7 +52,8 @@ add1.logistf<-function(object, scope, test="PLR", ...){
   mat<-matrix(0,nvar,3)
   for(i in 1:nvar){
     newform<-as.formula(paste(object$formula,variables[i], sep="+"))
-    res<-anova(object, update(object,formula=newform))
+    fit2 <- update(object, formula=newform, data = data)
+    res<-anova(object, fit2)
     mat[i,1]<-res$chisq
     mat[i,2]<-res$df
     mat[i,3]<-res$pval
@@ -62,18 +63,18 @@ add1.logistf<-function(object, scope, test="PLR", ...){
   return(mat)
 }
 #' @exportS3Method add1 flic
-add1.flic<-function(object, scope, test="PLR", ...){
-  add1.logistf(object, scope, ...)
+add1.flic<-function(object, scope, data, test="PLR", ...){
+  add1.logistf(object, scope, data, ...)
 }
 
 #' @exportS3Method add1 flac
-add1.flac<-function(object, scope, test="PLR", ...){
-  add1.logistf(object, scope, ...)
+add1.flac<-function(object, scope, data, test="PLR", ...){
+  add1.logistf(object, scope, data, ...)
 }
 #' @aliases drop1
 #' @method drop1 logistf
 #' @exportS3Method drop1 logistf
-drop1.logistf<-function(object, scope, test="PLR", ...){
+drop1.logistf<-function(object, scope, data, test="PLR", ...){
   mf <- match.call(expand.dots =FALSE)
   m <- match(c("object", "scope", "test"), names(mf), 0L)
   mf <- mf[c(1, m)]
@@ -117,12 +118,12 @@ drop1.logistf<-function(object, scope, test="PLR", ...){
 
 #' @method drop1 flic
 #' @exportS3Method drop1 flic
-drop1.flic<-function(object, scope, test="PLR", ...){
-  drop1.logistf(object, scope,  ...)
+drop1.flic<-function(object, scope, data, test="PLR", ...){
+  drop1.logistf(object, scope, data,  ...)
 }
 
 #' @method drop1 flac
 #' @exportS3Method drop1 flac
-drop1.flac<-function(object, scope, test="PLR", ...){
-  drop1.logistf(object, scope, augmented_data=TRUE,...)
+drop1.flac<-function(object, scope, data, test="PLR", ...){
+  drop1.logistf(object, scope, data, augmented_data=TRUE,...)
 }

--- a/R/add1.R
+++ b/R/add1.R
@@ -10,6 +10,7 @@
 #' @param scope The scope of variables considered for adding or dropping. Should be a 
 #' vector of variable names. Can be left missing; the method will then use all variables 
 #' in the object's data slot which are not identified as the response variable.
+#' @param data The data frame used to fit the object.
 #' @param test The type of test statistic. Currently, only the PLR test (penalized likelihood 
 #' ratio test) is allowed for logistf fits.
 #' @param ... Further arguments passed to or from other methods.
@@ -21,10 +22,10 @@
 #' @examples
 #' data(sex2) 
 #' fit<-logistf(data=sex2, case~1, pl=FALSE) 
-#' add1(fit, scope=c("dia", "age"))
+#' add1(fit, scope=c("dia", "age"), data=sex2)
 #'  
 #' fit2<-logistf(data=sex2, case~age+oc+dia+vic+vicl+vis) 
-#' drop1(fit2)
+#' drop1(fit2, data=sex2)
 #' 
 #' @importFrom stats add.scope
 #' @importFrom stats update.formula

--- a/R/backward.r
+++ b/R/backward.r
@@ -58,7 +58,7 @@ backward.logistf <- function(object, scope, data, steps=1000, slstay=0.05, trace
   terms.fit <- object$modcontrol$terms.fit
   if(!is.null(terms.fit)) stop("Please call backward on a logistf-object with all terms fitted.")
   
-  if(any(sapply(data[, variables], is.factor))) stop("Selecting among factor variables is not supported. Convert them to numeric dummy variables first.")
+  if(any(sapply(data[, variables], is.factor))) stop("Selecting among factor variables is not supported.")
 
   working<-object
   if(trace){
@@ -175,7 +175,7 @@ forward.logistf<-function(object, scope, data, steps=1000, slentry=0.05, trace=T
   terms.fit <- object$modcontrol$terms.fit
   if(!is.null(terms.fit)) stop("Please call forward on a logistf-object with all terms fitted.")
   
-  if(any(sapply(data[, scope], is.factor))) stop("Selecting among factor variables is not supported. Convert them to numeric dummy variables first.")
+  if(any(sapply(data[, scope], is.factor))) stop("Selecting among factor variables is not supported.")
   
   working<-object
   if(missing(scope)) {

--- a/R/backward.r
+++ b/R/backward.r
@@ -3,8 +3,13 @@
 #' These functions provide simple backward elimination/forward selection procedures for logistf models.
 #' 
 #' The variable selection is simply performed by repeatedly calling add1 or drop1 methods for logistf, 
-#' and is based on penalized likelihood ratio test. It can also properly handle variables that were 
-#' defined as factors in the original data set.
+#' and is based on penalized likelihood ratio test.
+#' 
+#' Note that selecting among factor variables is not supported.
+#' One way to use forward or backward with factor variables is to first convert them
+#' into numeric variables (0/1 coded dummy variables, choosing a sensible reference category).
+#' Forward and backward will then perform selection on the dummy variables, 
+#' meaning that it will collapse levels of a factor variable with similar outcomes.
 #' 
 #' @param object A fitted logistf model object. To start with an empty model, create a model fit 
 #' with a formula= y~1, pl=FALSE. (Replace y by your response variable.)
@@ -22,6 +27,7 @@
 #' @param ... Further arguments to be passed to methods.
 #'
 #' @return An updated \code{logistf, flic} or \code{flac} fit with the finally selected model.
+#'
 #'
 #' @examples 
 #' data(sex2) 

--- a/R/backward.r
+++ b/R/backward.r
@@ -57,6 +57,8 @@ backward.logistf <- function(object, scope, data, steps=1000, slstay=0.05, trace
   
   terms.fit <- object$modcontrol$terms.fit
   if(!is.null(terms.fit)) stop("Please call backward on a logistf-object with all terms fitted.")
+  
+  if(any(sapply(data[, variables], is.factor))) stop("Selecting among factor variables is not supported. Convert them to numeric dummy variables first.")
 
   working<-object
   if(trace){
@@ -172,6 +174,8 @@ forward.logistf<-function(object, scope, data, steps=1000, slentry=0.05, trace=T
   
   terms.fit <- object$modcontrol$terms.fit
   if(!is.null(terms.fit)) stop("Please call forward on a logistf-object with all terms fitted.")
+  
+  if(any(sapply(data[, scope], is.factor))) stop("Selecting among factor variables is not supported. Convert them to numeric dummy variables first.")
   
   working<-object
   if(missing(scope)) {

--- a/R/backward.r
+++ b/R/backward.r
@@ -11,6 +11,7 @@
 #' @param scope The scope of variables to add/drop from the model. Can be missing for backward, backward will use 
 #' the terms of the object fit. Alternatively, an arbitrary vector of variable names can be given, to allow 
 #' that only some of the variables will be competitively selected or dropped. Has to be provided for forward.
+#' @param data The data frame used to fit the object.
 #' @param steps The number of forward selection/backward elimination steps.
 #' @param slstay For \code{backward}, the significance level to stay in the model.
 #' @param slentry For \code{forward}, the significance level to enter the model.
@@ -25,10 +26,10 @@
 #' @examples 
 #' data(sex2) 
 #' fit<-logistf(data=sex2, case~1, pl=FALSE) 
-#' fitf<-forward(fit, scope = c("dia", "age")) 
+#' fitf<-forward(fit, scope=c("dia", "age"), data=sex2) 
 #' 
 #' fit2<-logistf(data=sex2, case~age+oc+vic+vicl+vis+dia) 
-#' fitb<-backward(fit2)
+#' fitb<-backward(fit2, data=sex2)
 #' 
 #' @importFrom utils tail
 #' 
@@ -90,7 +91,7 @@ backward.logistf <- function(object, scope, data, steps=1000, slstay=0.05, trace
       mat <- drop1(object, scope=inscope, data = data, full.penalty.vec=removal,...)
     }
     else {
-      mat<-drop1(working,scope=inscope, data = data...)
+      mat<-drop1(working,scope=inscope, data = data, ...)
     }
     istep<-istep+1
     if(all(mat[,3]<slstay)) {

--- a/R/logistf.R
+++ b/R/logistf.R
@@ -103,8 +103,8 @@
 #' snpdata$case<-c(rep(0,100),rep(1,100))
 #' 
 #' fitsnp<-logistf(data=snpdata, formula=case~1, pl=FALSE)
-#' add1(fitsnp, scope=paste("SNP",1:20,"_",sep=""))
-#' fitf<-forward(fitsnp, scope = paste("SNP",1:20,"_",sep=""))
+#' add1(fitsnp, scope=paste("SNP",1:20,"_",sep=""), data=snpdata)
+#' fitf<-forward(fitsnp, scope = paste("SNP",1:20,"_",sep=""), data=snpdata)
 #' fitf
 #' 
 #' @author Georg Heinze and Meinhard Ploner

--- a/R/logistf.R
+++ b/R/logistf.R
@@ -99,7 +99,6 @@
 #'   matrix(rbinom(2000,2,runif(2000)*0.5),100,20))
 #' colnames(snpdata)<-paste("SNP",1:20,"_",sep="")
 #' snpdata<-as.data.frame(snpdata)
-#' for(i in 1:20) snpdata[,i]<-as.factor(snpdata[,i])
 #' snpdata$case<-c(rep(0,100),rep(1,100))
 #' 
 #' fitsnp<-logistf(data=snpdata, formula=case~1, pl=FALSE)

--- a/man/add1.Rd
+++ b/man/add1.Rd
@@ -5,7 +5,7 @@
 \alias{add1.logistf}
 \title{Add or Drop All Possible Single Terms to/from a \code{logistf} Model}
 \usage{
-\method{add1}{logistf}(object, scope, test = "PLR", ...)
+\method{add1}{logistf}(object, scope, data, test = "PLR", ...)
 }
 \arguments{
 \item{object}{A fitted \code{logistf, flic} or \code{flac} object}

--- a/man/add1.Rd
+++ b/man/add1.Rd
@@ -14,6 +14,8 @@
 vector of variable names. Can be left missing; the method will then use all variables
 in the object's data slot which are not identified as the response variable.}
 
+\item{data}{The data frame used to fit the object.}
+
 \item{test}{The type of test statistic. Currently, only the PLR test (penalized likelihood
 ratio test) is allowed for logistf fits.}
 
@@ -33,9 +35,9 @@ likelihood ratio chi-squared, the degrees of freedom, and the p-value for droppi
 \examples{
 data(sex2) 
 fit<-logistf(data=sex2, case~1, pl=FALSE) 
-add1(fit, scope=c("dia", "age"))
+add1(fit, scope=c("dia", "age"), data=sex2)
  
 fit2<-logistf(data=sex2, case~age+oc+dia+vic+vicl+vis) 
-drop1(fit2)
+drop1(fit2, data=sex2)
 
 }

--- a/man/backward.Rd
+++ b/man/backward.Rd
@@ -57,6 +57,8 @@ with a formula= y~1, pl=FALSE. (Replace y by your response variable.)}
 the terms of the object fit. Alternatively, an arbitrary vector of variable names can be given, to allow
 that only some of the variables will be competitively selected or dropped. Has to be provided for forward.}
 
+\item{data}{The data frame used to fit the object.}
+
 \item{steps}{The number of forward selection/backward elimination steps.}
 
 \item{slstay}{For \code{backward}, the significance level to stay in the model.}
@@ -90,9 +92,9 @@ defined as factors in the original data set.
 \examples{
 data(sex2) 
 fit<-logistf(data=sex2, case~1, pl=FALSE) 
-fitf<-forward(fit, scope = c("dia", "age")) 
+fitf<-forward(fit, scope=c("dia", "age"), data=sex2) 
 
 fit2<-logistf(data=sex2, case~age+oc+vic+vicl+vis+dia) 
-fitb<-backward(fit2)
+fitb<-backward(fit2, data=sex2)
 
 }

--- a/man/backward.Rd
+++ b/man/backward.Rd
@@ -13,6 +13,7 @@ backward(object, ...)
 \method{backward}{logistf}(
   object,
   scope,
+  data,
   steps = 1000,
   slstay = 0.05,
   trace = TRUE,
@@ -37,6 +38,7 @@ forward(object, ...)
 \method{forward}{logistf}(
   object,
   scope,
+  data,
   steps = 1000,
   slentry = 0.05,
   trace = TRUE,

--- a/man/backward.Rd
+++ b/man/backward.Rd
@@ -81,8 +81,13 @@ These functions provide simple backward elimination/forward selection procedures
 }
 \details{
 The variable selection is simply performed by repeatedly calling add1 or drop1 methods for logistf,
-and is based on penalized likelihood ratio test. It can also properly handle variables that were
-defined as factors in the original data set.
+and is based on penalized likelihood ratio test.
+
+Note that selecting among factor variables is not supported.
+One way to use forward or backward with factor variables is to first convert them
+into numeric variables (0/1 coded dummy variables, choosing a sensible reference category).
+Forward and backward will then perform selection on the dummy variables,
+meaning that it will collapse levels of a factor variable with similar outcomes.
 }
 \section{Functions}{
 \itemize{

--- a/man/logistf.Rd
+++ b/man/logistf.Rd
@@ -142,8 +142,8 @@ for(i in 1:20) snpdata[,i]<-as.factor(snpdata[,i])
 snpdata$case<-c(rep(0,100),rep(1,100))
 
 fitsnp<-logistf(data=snpdata, formula=case~1, pl=FALSE)
-add1(fitsnp, scope=paste("SNP",1:20,"_",sep=""))
-fitf<-forward(fitsnp, scope = paste("SNP",1:20,"_",sep=""))
+add1(fitsnp, scope=paste("SNP",1:20,"_",sep=""), data=snpdata)
+fitf<-forward(fitsnp, scope = paste("SNP",1:20,"_",sep=""), data=snpdata)
 fitf
 
 }

--- a/man/logistf.Rd
+++ b/man/logistf.Rd
@@ -138,7 +138,6 @@ snpdata<-rbind(
   matrix(rbinom(2000,2,runif(2000)*0.5),100,20))
 colnames(snpdata)<-paste("SNP",1:20,"_",sep="")
 snpdata<-as.data.frame(snpdata)
-for(i in 1:20) snpdata[,i]<-as.factor(snpdata[,i])
 snpdata$case<-c(rep(0,100),rep(1,100))
 
 fitsnp<-logistf(data=snpdata, formula=case~1, pl=FALSE)


### PR DESCRIPTION
Theresa made me aware of a bug in `backward.logistf()` and `forward.logistf()`. When used inside a function, they do not find the data.frame they need to update the model. I added a data argument, so the user now needs to pass the data.frame to `backward.logistf()` and `forward.logistf()`. This solves the issue and avoids any scoping problems.

I also added an error message when selecting among factor variables, as this can lead to unexpected behavior.
