### PR TITLE
Add tidy method for logistf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person("Georg", "Heinze", role=c("aut", "cre"), email="georg.heinze
 			 person("Lena", "Jiricka", role=c("aut")),
 			 person("Gregor", "Steiner", role=c("aut")))
 Depends: R (>= 3.0.0)
-Imports: mice, mgcv, formula.tools, Matrix
+Imports: generics, mice, mgcv, formula.tools, Matrix
 Suggests: emmeans (>= 1.4), estimability
 Description: Fit a logistic regression model using Firth's bias reduction method, equivalent to penalization of the log-likelihood by the Jeffreys 
 	prior. Confidence intervals for regression coefficients can be computed by penalized profile likelihood. Firth's method was proposed as ideal

--- a/R/tidy.logistf.R
+++ b/R/tidy.logistf.R
@@ -1,0 +1,57 @@
+#' tidy method for logistf objects
+#'
+#' @param x model object
+#' @param conf.int binary indicating whether to include confidence intervals
+#' @param exponentiate binary indicating whether to exponentiate coefficients
+#' @param ... Additional arguments. Not used.
+#'
+#' @note
+#' Most tidy methods provide a conf.level argument to set the confidence level.
+#' Supplying one to this function only produces a warning, as the confidence
+#' level should be set in the logistf call, via the alpha argument.
+#'
+#' @return
+#' @export
+#'
+#' @examples
+#' data(sex2)
+#' fit<-logistf(case ~ age+oc+vic+vicl+vis+dia, data=sex2)
+#' tidy(fit)
+tidy.logistf <- function(x,
+                         conf.int = FALSE,
+                         exponentiate = TRUE,
+                         ...){
+
+  dots <- list(...)
+  if(length(dots) > 0){
+    if("conf.level" %in% names(dots)){
+      warning(paste("set conf.level in the logistf call (alpha argument)",
+                    x$conflev, "used instead"))
+    }
+  }
+
+  result <- data.frame(term = names(coef(x)),
+                       estimate = coef(x),
+                       std.error = vcov(x) |> diag() |> sqrt(),
+                       statistic = qchisq(1 - x$prob, 1),
+                       p.value = x$prob,
+                       row.names = NULL)
+
+  if(conf.int){
+    result$conf.low <- x$ci.lower
+    result$conf.high <- x$ci.upper
+  }
+  if(exponentiate){
+    result$estimate <- exp(result$estimate)
+    if(conf.int){
+      result$conf.low <- exp(result$conf.low)
+      result$conf.high <- exp(result$conf.high)
+    }
+  }
+
+  result
+}
+
+#' @importFrom generics tidy
+#' @export
+generics::tidy


### PR DESCRIPTION
Here is a tidy method for `logistf`. I'm not sure whether glance or augment functions are useful in this case. I needed the tidy method, so here you have it ;)

I've not run `devtools::document()` or `check()`, so it may be that R complains about dependencies from the `stats` package.